### PR TITLE
fix: overlay dialog options not visible in maximized terminal

### DIFF
--- a/lib/components/android_launch_dialog.dart
+++ b/lib/components/android_launch_dialog.dart
@@ -58,7 +58,7 @@ class _LaunchDialogState extends State<AndroidLaunchDialog> {
                 Divider(),
                 Text(
                   ' Navigate: <↑/↓> | Launch: <enter> | Cancel: <esc>',
-                  style: st.dimmed,
+                  style: st.dialogHint,
                 ),
               ],
             ),
@@ -78,7 +78,10 @@ class _LaunchDialogState extends State<AndroidLaunchDialog> {
       children: [
         Text(isSelected ? ' ${SimutilIcons.pointer} ' : '   ', style: st.label),
         Expanded(
-          child: Text(option.label, style: isSelected ? st.selected : st.body),
+          child: Text(
+            option.label,
+            style: isSelected ? st.sectionHeader : st.dialogBody,
+          ),
         ),
       ],
     );

--- a/lib/components/error_dialog.dart
+++ b/lib/components/error_dialog.dart
@@ -49,7 +49,7 @@ class ErrorDialog extends StatelessComponent {
                 Text(' $message', style: st.errorStyle),
                 SizedBox(height: 1),
                 Divider(),
-                Text(' Close: <enter> | <esc>', style: st.dimmed),
+                Text(' Close: <enter> | <esc>', style: st.dialogHint),
               ],
             ),
           ),

--- a/lib/components/input_dialog.dart
+++ b/lib/components/input_dialog.dart
@@ -77,10 +77,10 @@ class _InputDialogState extends State<InputDialog> {
                 _buildInputField(st),
                 if (component.hint.isNotEmpty) ...[
                   SizedBox(height: 1),
-                  Text(' ${component.hint}', style: st.dimmed),
+                  Text(' ${component.hint}', style: st.dialogHint),
                 ],
                 Divider(),
-                Text(' Submit: <enter> | Cancel: <esc>', style: st.dimmed),
+                Text(' Submit: <enter> | Cancel: <esc>', style: st.dialogHint),
               ],
             ),
           ),

--- a/lib/components/show_overlay_dialog.dart
+++ b/lib/components/show_overlay_dialog.dart
@@ -9,6 +9,10 @@ typedef OverlayDialogBuilder<T> =
       OverlayEntry? entry,
     );
 
+/// Shows an overlay dialog with a dimmed modal barrier backdrop.
+///
+/// The [FadeModalBarrier] ensures the background content is dimmed,
+/// making the dialog clearly visible even on maximized terminal windows.
 Future<T?> showOverlayDialog<T>({
   required BuildContext context,
   required OverlayDialogBuilder<T> builder,
@@ -19,7 +23,18 @@ Future<T?> showOverlayDialog<T>({
   entry = OverlayEntry(
     opaque: false,
     builder: (context) {
-      return builder(context, completer, entry);
+      return Stack(
+        children: [
+          // Dimmed backdrop to occlude underlying content
+          FadeModalBarrier(
+            color: Colors.black.withOpacity(0.6),
+            dismissible: false,
+            duration: const Duration(milliseconds: 100),
+          ),
+          // Actual dialog content rendered on top
+          builder(context, completer, entry),
+        ],
+      );
     },
   );
 

--- a/lib/components/simutil_theme.dart
+++ b/lib/components/simutil_theme.dart
@@ -29,6 +29,14 @@ class SimutilTheme {
 
   TextStyle get selected => const TextStyle(reverse: true);
 
+  /// Text style for dialog body content — uses explicit [onBackground] color
+  /// so text is legible against the dialog's dark [background] fill.
+  TextStyle get dialogBody => TextStyle(color: onBackground);
+
+  /// Text style for dialog hint/footer text — uses [outline] color for
+  /// a subtler appearance while remaining readable in dialogs.
+  TextStyle get dialogHint => TextStyle(color: outline);
+
   TextStyle get label => TextStyle(color: primary);
 
   TextStyle get sectionHeader =>

--- a/lib/components/success_dialog.dart
+++ b/lib/components/success_dialog.dart
@@ -50,7 +50,7 @@ class SuccessDialog extends StatelessComponent {
                 Text(' $message', style: st.successStyle),
                 SizedBox(height: 1),
                 Divider(),
-                Text(' Close: <enter> | <esc>', style: st.dimmed),
+                Text(' Close: <enter> | <esc>', style: st.dialogHint),
               ],
             ),
           ),

--- a/lib/plugins/adb_tools/adb_tools_dialog.dart
+++ b/lib/plugins/adb_tools/adb_tools_dialog.dart
@@ -66,7 +66,7 @@ class _AdbToolsDialogState extends State<AdbToolsDialog> {
                 Divider(),
                 Text(
                   ' Navigate: <↑/↓> | Select: <enter> | Cancel: <esc>',
-                  style: st.dimmed,
+                  style: st.dialogHint,
                 ),
               ],
             ),
@@ -91,7 +91,7 @@ class _AdbToolsDialogState extends State<AdbToolsDialog> {
             Text(option.label, style: isSelected ? st.selected : st.bold),
           ],
         ),
-        Text('   ${option.description}', style: st.dimmed),
+        Text('   ${option.description}', style: st.dialogHint),
         SizedBox(height: 1),
       ],
     );

--- a/lib/plugins/adb_tools/qr_connect_dialog.dart
+++ b/lib/plugins/adb_tools/qr_connect_dialog.dart
@@ -41,7 +41,7 @@ class _QrConnectDialogState extends State<QrConnectDialog> {
               children: [
                 _buildQrArt(),
                 Divider(),
-                Text(' Close: <enter> or <esc>', style: st.dimmed),
+                Text(' Close: <enter> or <esc>', style: st.dialogHint),
               ],
             ),
           ),

--- a/lib/plugins/adb_tools/wireless_pairing_dialog.dart
+++ b/lib/plugins/adb_tools/wireless_pairing_dialog.dart
@@ -103,16 +103,16 @@ class _WirelessPairingDialogState extends State<WirelessPairingDialog> {
                 Text(' Steps to pair:', style: st.label),
                 Text(
                   '  1. On your Android device, go to Developer Options',
-                  style: st.dimmed,
+                  style: st.dialogHint,
                 ),
-                Text('  2. Enable "Wireless debugging"', style: st.dimmed),
+                Text('  2. Enable "Wireless debugging"', style: st.dialogHint),
                 Text(
                   '  3. Tap "Pair device with pairing code"',
-                  style: st.dimmed,
+                  style: st.dialogHint,
                 ),
                 Text(
                   '  4. Enter the IP:Port and 6-digit pairing code below',
-                  style: st.dimmed,
+                  style: st.dialogHint,
                 ),
                 Divider(),
                 _buildInputField(
@@ -133,7 +133,7 @@ class _WirelessPairingDialogState extends State<WirelessPairingDialog> {
                 Divider(),
                 Text(
                   ' Switch field: <tab> | Pair: <enter> | Cancel: <esc>',
-                  style: st.dimmed,
+                  style: st.dialogHint,
                 ),
               ],
             ),
@@ -156,7 +156,7 @@ class _WirelessPairingDialogState extends State<WirelessPairingDialog> {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(' $label:', style: isFocused ? st.label : st.body),
+        Text(' $label:', style: isFocused ? st.label : st.dialogBody),
         Row(
           children: [
             Text('  ', style: st.body),
@@ -165,8 +165,8 @@ class _WirelessPairingDialogState extends State<WirelessPairingDialog> {
                 controller: controller,
                 focused: isFocused,
                 placeholder: placeholder,
-                placeholderStyle: st.dimmed,
-                style: st.body,
+                placeholderStyle: st.dialogHint,
+                style: st.dialogBody,
                 onSubmitted: (_) => _trySubmit(),
                 decoration: InputDecoration(
                   border: BoxBorder.all(


### PR DESCRIPTION
## Description

Fix overlay dialog visibility issues when running SimUtil in maximized terminal windows.

**Problem:**
When launching an Android emulator via the launch dialog, the popup options (Normal, Cold Boot, No Audio, Cold Boot + No Audio) were nearly invisible because:
1. The overlay dialog had no backdrop — underlying UI content bled through behind the dialog
2. Text inside the dialog used styles with no explicit foreground color (`st.body`, `st.dimmed`), which blended into the dark dialog background
3. The selected option used `reverse` styling which became invisible against the dark background

**Fix:**
- Added a `FadeModalBarrier` with a dimmed backdrop (`Stack` + 60% black overlay) to `showOverlayDialog()` so all overlay dialogs properly obscure the background content
- Added `dialogBody` and `dialogHint` text styles to `SimutilTheme` with explicit `onBackground` and `outline` colors for proper contrast inside dialogs
- Updated all dialog components to use these new styles: `AndroidLaunchDialog`, `AdbToolsDialog`, `InputDialog`, `ErrorDialog`, `SuccessDialog`, `WirelessPairingDialog`, `QrConnectDialog`
- Changed selected option styling from `reverse` to `sectionHeader` (primary + bold) for clear visibility


Before fix:

<img width="1466" height="919" alt="Screenshot 2026-03-28 at 10 52 52" src="https://github.com/user-attachments/assets/0e91b695-f92d-47f6-9f0f-49332b7b7dd7" />


After fix:

<img width="1458" height="920" alt="Screenshot 2026-03-28 at 10 53 46" src="https://github.com/user-attachments/assets/c2ff9ea7-6661-4ed2-97c9-dbcd40163194" />

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore