### PR TITLE
fix: ios devices are still visible but states are unavailable

### DIFF
--- a/lib/services/ios_device_service.dart
+++ b/lib/services/ios_device_service.dart
@@ -167,13 +167,16 @@ class IOSDeviceService implements DeviceService {
       final map = d as Map<String, dynamic>;
       final deviceProps =
           map['deviceProperties'] as Map<String, dynamic>? ?? {};
+      final connectionProps =
+          map['connectionProperties'] as Map<String, dynamic>? ?? {};
       final identifier = map['identifier'] as String? ?? '';
       final name = deviceProps['name'] as String? ?? '';
       final osVersion = deviceProps['osVersionNumber'] as String? ?? '';
+      final tunnelState = connectionProps['tunnelState'] as String?;
       final booted = ![
         'unavailable',
         'disconnected',
-      ].contains(map['connectionProperties']['tunnelState']);
+      ].contains(tunnelState);
       if (!booted) continue;
       devices.add(
         Device.ios(

--- a/lib/services/ios_device_service.dart
+++ b/lib/services/ios_device_service.dart
@@ -173,11 +173,11 @@ class IOSDeviceService implements DeviceService {
       final name = deviceProps['name'] as String? ?? '';
       final osVersion = deviceProps['osVersionNumber'] as String? ?? '';
       final tunnelState = connectionProps['tunnelState'] as String?;
-      final booted = ![
+      final isConnected = ![
         'unavailable',
         'disconnected',
       ].contains(tunnelState);
-      if (!booted) continue;
+      if (!isConnected) continue;
       devices.add(
         Device.ios(
           id: identifier,

--- a/lib/services/ios_device_service.dart
+++ b/lib/services/ios_device_service.dart
@@ -170,6 +170,11 @@ class IOSDeviceService implements DeviceService {
       final identifier = map['identifier'] as String? ?? '';
       final name = deviceProps['name'] as String? ?? '';
       final osVersion = deviceProps['osVersionNumber'] as String? ?? '';
+      final booted = ![
+        'unavailable',
+        'disconnected',
+      ].contains(map['connectionProperties']['tunnelState']);
+      if (!booted) continue;
       devices.add(
         Device.ios(
           id: identifier,

--- a/lib/simutil_app.dart
+++ b/lib/simutil_app.dart
@@ -165,7 +165,7 @@ class _SimutilAppState extends State<SimutilApp> {
 
         // By default always keep focus on simulators / emulator list
         final hasAndroidDevices = _androidDevices.isNotEmpty;
-        final hasIosDevices = _iosSimulators.isNotEmpty;
+        final hasIosDevices = _iosDevices.isNotEmpty;
 
         final isFocusingOnEmptyAndroidDevicesPanel =
             _focusKey == 'android' && !hasAndroidDevices;


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- fix: ios devices are still visible but states are unavailable

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS physical devices panel to correctly focus when devices are available
  * Improved physical device detection to filter and display only connected iOS devices
  * Enhanced panel focus logic for more reliable keyboard navigation in device management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->