### PR TITLE
Fix incorrect way to terminate app

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -11,7 +11,7 @@ changelog:
         - enhancement
     - title: Fixes 🔧
       labels:
-        - bug
+        - fixbug
     - title: Docs 📖
       labels:
         - docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-11
+
+### Fixed
+
+- Fix incorrect way to terminate app.
+
 ## [0.4.0] - 2026-04-05
 
 ### Added

--- a/lib/simutil_app.dart
+++ b/lib/simutil_app.dart
@@ -297,7 +297,8 @@ class _SimutilAppState extends State<SimutilApp> {
       case LogicalKey.keyS:
         return true;
       case LogicalKey.keyQ:
-        exit(0);
+        shutdownApp();
+        return true;
       default:
         return false;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simutil
 description: TUI application for launching Android Simulators / iOS Simulators and more ...
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/dungngminh/simutil
 
 environment:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- Fixes #20 
- Use `shutdownApp` to exit app [safely](https://pub.dev/documentation/nocterm/latest/nocterm/shutdownApp.html) and clear all buffering data

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🔥 New feature (non-breaking change which adds functionality)
- [ ] ✨ Enhancement (non-breaking change which improves existing functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 📦 Build configuration change
- [ ] ✅ Test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incorrect app termination behavior.

* **Chores**
  * Version bumped to 0.4.1.
  * Updated release notes categorization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->