### PR TITLE
Add Windows PowerShell installer for simutil

### DIFF
--- a/.github/workflows/test-install-ps1.yaml
+++ b/.github/workflows/test-install-ps1.yaml
@@ -1,0 +1,47 @@
+name: Test Windows PowerShell Installer
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "install.ps1"
+      - ".github/workflows/test-install-ps1.yaml"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "install.ps1"
+      - ".github/workflows/test-install-ps1.yaml"
+  workflow_dispatch:
+
+jobs:
+  test-install-ps1:
+    name: Run install.ps1 on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Execute installer script
+        shell: pwsh
+        run: |
+          .\install.ps1
+
+      - name: Verify installed binary and PATH
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:LOCALAPPDATA "simutil"
+          $exePath = Join-Path $installDir "simutil.exe"
+
+          if (-not (Test-Path $exePath)) {
+            throw "Expected binary not found at $exePath"
+          }
+
+          Write-Host "Running '$exePath version'..."
+          & $exePath version
+
+          $cmd = Get-Command simutil -ErrorAction SilentlyContinue
+          if (-not $cmd) {
+            throw "simutil is not available in PATH after installation."
+          }
+
+          Write-Host "simutil resolves to: $($cmd.Source)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add Windows PowerShell installer command (`install.ps1`) to README installation section.
+
 ## [0.4.1] - 2026-04-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Simutil is written with [Nocterm](https://nocterm.dev/), a terminal UI framework
 curl -fsSL https://raw.githubusercontent.com/dungngminh/simutil/main/install.sh | bash
 ```
 
+### Binary Install (Windows PowerShell)
+
+```powershell
+powershell -ExecutionPolicy Bypass -Command "iwr -useb https://raw.githubusercontent.com/dungngminh/simutil/main/install.ps1 | iex"
+```
+
 ### Using Homebrew (macOS/Linux)
 
 ```bash

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,164 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param(
+    [string]$Version = "latest"
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "dungngminh/simutil"
+$BinaryName = "simutil.exe"
+$InstallDir = Join-Path $env:LOCALAPPDATA "simutil"
+$InstalledBinaryPath = Join-Path $InstallDir $BinaryName
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[info]  $Message" -ForegroundColor Cyan
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[ok]    $Message" -ForegroundColor Green
+}
+
+function Write-Warn {
+    param([string]$Message)
+    Write-Host "[warn]  $Message" -ForegroundColor Yellow
+}
+
+function Fail {
+    param([string]$Message)
+    Write-Host "[err]   $Message" -ForegroundColor Red
+    exit 1
+}
+
+function Resolve-Version {
+    param([string]$RequestedVersion)
+
+    if ($RequestedVersion -ne "latest") {
+        return $RequestedVersion
+    }
+
+    Write-Info "Resolving latest release..."
+
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -Headers @{
+            "Accept" = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+        }
+    }
+    catch {
+        Fail "Could not query latest release from GitHub. $_"
+    }
+
+    if (-not $release.tag_name) {
+        Fail "Could not determine latest release tag."
+    }
+
+    return $release.tag_name
+}
+
+function Ensure-UserPathContainsInstallDir {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $parts = @()
+
+    if ($userPath) {
+        $parts = $userPath -split ";"
+    }
+
+    $alreadyPresent = $parts | Where-Object { $_.TrimEnd("\") -ieq $InstallDir.TrimEnd("\") }
+
+    # In GitHub Actions, each step starts a new process. Writing to GITHUB_PATH
+    # ensures the install dir is available on PATH in subsequent steps.
+    if ($env:GITHUB_PATH) {
+        Add-Content -Path $env:GITHUB_PATH -Value $InstallDir
+        Write-Info "Exported $InstallDir to GITHUB_PATH for CI steps"
+    }
+
+    if ($alreadyPresent) {
+        Write-Info "User PATH already contains $InstallDir"
+        return
+    }
+
+    $newPath = if ([string]::IsNullOrWhiteSpace($userPath)) {
+        $InstallDir
+    }
+    else {
+        "$userPath;$InstallDir"
+    }
+
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    $env:Path = "$env:Path;$InstallDir"
+    Write-Success "Added $InstallDir to your user PATH"
+}
+
+function Install-Simutil {
+    param([string]$ResolvedVersion)
+
+    $assetName = "simutil-windows-x64.zip"
+    $downloadUrl = "https://github.com/$Repo/releases/download/$ResolvedVersion/$assetName"
+
+    Write-Info "Version:   $ResolvedVersion"
+    Write-Info "Asset:     $assetName"
+    Write-Info "Downloading from $downloadUrl"
+
+    $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("simutil-install-" + [System.Guid]::NewGuid().ToString("N"))
+    $zipPath = Join-Path $tmpRoot $assetName
+    $extractDir = Join-Path $tmpRoot "extract"
+
+    New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+    New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+    }
+    catch {
+        Remove-Item -Path $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Fail "Download failed. Make sure release '$ResolvedVersion' exists and includes '$assetName'."
+    }
+
+    if (-not (Test-Path $zipPath) -or ((Get-Item $zipPath).Length -le 0)) {
+        Remove-Item -Path $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Fail "Downloaded file is missing or empty."
+    }
+
+    Write-Info "Extracting archive..."
+    Expand-Archive -Path $zipPath -DestinationPath $extractDir -Force
+
+    $candidatePaths = @(
+        (Join-Path $extractDir "simutil-windows-x64.exe"),
+        (Join-Path $extractDir "simutil.exe")
+    )
+
+    $sourceBinary = $null
+    foreach ($candidate in $candidatePaths) {
+        if (Test-Path $candidate) {
+            $sourceBinary = $candidate
+            break
+        }
+    }
+
+    if (-not $sourceBinary) {
+        Remove-Item -Path $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+        Fail "Could not find simutil executable in extracted archive."
+    }
+
+    Copy-Item -Path $sourceBinary -Destination $InstalledBinaryPath -Force
+    Remove-Item -Path $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+
+    Write-Success "Installed to $InstalledBinaryPath"
+}
+
+if (-not $IsWindows) {
+    Fail "This installer only supports Windows."
+}
+
+$resolved = Resolve-Version -RequestedVersion $Version
+Install-Simutil -ResolvedVersion $resolved
+Ensure-UserPathContainsInstallDir
+
+Write-Host ""
+Write-Success "Installation completed."
+Write-Host "Run 'simutil' in a new PowerShell window."


### PR DESCRIPTION
## Description

Added Windows PowerShell installer (`install.ps1`) — downloads `simutil.exe` from GitHub Releases, installs to `%LOCALAPPDATA%\simutil`, adds install dir to user `PATH`. Supports `-Version` param (default: `latest`).

Added CI workflow (`.github/workflows/test-install-ps1.yaml`) to test installer on Windows runner.

## Type of Change

- [x] 🔥 New feature (non-breaking change which adds functionality)
- [ ] ✨ Enhancement (non-breaking change which improves existing functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 📦 Build configuration change
- [x] ✅ Test



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows PowerShell installer script enables easy simutil installation with automatic environment setup
  * Supports version selection during installation—defaults to latest release when no version specified  
  * Includes built-in validation checks and automatic cleanup of temporary installation files
  * Automatic PATH environment configuration for seamless access

* **Chores**
  * Added automated testing workflow for continuous Windows installer validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->