### PR TITLE
Fix Linux ADB discovery and SSH terminal restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix Android ADB discovery on Linux by checking `$HOME/Android/Sdk` and falling back to `adb` on `PATH` when no SDK-managed binary is present.
 - Stop treating all Android physical devices as fully booted when `adb devices -l` reports intermediate states such as `unauthorized` or `offline`.
+- Restore SSH terminal and TTY state on Linux after quitting remote sessions.
 
 ## [0.6.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Android ADB discovery on Linux by checking `$HOME/Android/Sdk` and falling back to `adb` on `PATH` when no SDK-managed binary is present.
+- Stop treating all Android physical devices as fully booted when `adb devices -l` reports intermediate states such as `unauthorized` or `offline`.
+
 ## [0.6.0] - 2026-06-26
 
 ### Added

--- a/bin/simutil.dart
+++ b/bin/simutil.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:async';
 
 import 'package:nocterm/nocterm.dart';
 import 'package:simutil/cli/simutil_command_runner.dart';
@@ -21,6 +22,7 @@ Future<void> main(List<String> arguments) async {
 
 Future<void> _runTuiSupervisor() async {
   final ttyState = await _captureTerminalState();
+  final signalSubscriptions = <StreamSubscription<ProcessSignal>>[];
   try {
     final child = await Process.start(
       _currentExecutableCommand(),
@@ -28,8 +30,12 @@ Future<void> _runTuiSupervisor() async {
       mode: ProcessStartMode.inheritStdio,
       environment: {...Platform.environment, _tuiChildEnvVar: '1'},
     );
+    signalSubscriptions.addAll(_forwardSignalsToChild(child.pid));
     exitCode = await child.exitCode;
   } finally {
+    for (final subscription in signalSubscriptions) {
+      await subscription.cancel();
+    }
     await _restoreTerminalState(ttyState);
   }
 }
@@ -86,7 +92,6 @@ Future<ProcessResult> _runStty(List<String> arguments) {
 }
 
 Future<void> _restoreTerminalScreenState() async {
-  final shell = Platform.environment['SHELL'] ?? '/bin/sh';
   final term = Platform.environment['TERM'];
 
   if (term != null && term.isNotEmpty) {
@@ -95,8 +100,31 @@ Future<void> _restoreTerminalScreenState() async {
     await Process.run('tput', ['sgr0']);
   }
 
-  await Process.run(shell, [
-    '-lc',
-    "printf '\\033[?1049l\\033[?25h\\033[0m\\r' > /dev/tty",
-  ]);
+  try {
+    final tty = File('/dev/tty').openSync(mode: FileMode.writeOnlyAppend);
+    try {
+      tty.writeStringSync('\x1b[?1049l\x1b[?25h\x1b[0m\r');
+    } finally {
+      tty.closeSync();
+    }
+  } catch (_) {}
+}
+
+List<StreamSubscription<ProcessSignal>> _forwardSignalsToChild(int pid) {
+  if (!(Platform.isLinux || Platform.isMacOS)) return const [];
+
+  return [
+    ProcessSignal.sigwinch.watch().listen((_) {
+      Process.killPid(pid, ProcessSignal.sigwinch);
+    }),
+    ProcessSignal.sigterm.watch().listen((_) {
+      Process.killPid(pid, ProcessSignal.sigterm);
+    }),
+    ProcessSignal.sighup.watch().listen((_) {
+      Process.killPid(pid, ProcessSignal.sighup);
+    }),
+    ProcessSignal.sigint.watch().listen((_) {
+      Process.killPid(pid, ProcessSignal.sigint);
+    }),
+  ];
 }

--- a/bin/simutil.dart
+++ b/bin/simutil.dart
@@ -1,11 +1,102 @@
+import 'dart:io';
+
 import 'package:nocterm/nocterm.dart';
 import 'package:simutil/cli/simutil_command_runner.dart';
 import 'package:simutil/simutil_app.dart';
 
-void main(List<String> arguments) {
+const _tuiChildEnvVar = 'SIMUTIL_TUI_CHILD';
+
+Future<void> main(List<String> arguments) async {
   if (arguments.isEmpty) {
-    runApp(Navigator(home: const SimutilApp()));
+    if (Platform.isLinux && Platform.environment[_tuiChildEnvVar] != '1') {
+      await _runTuiSupervisor();
+      return;
+    }
+
+    await runApp(Navigator(home: const SimutilApp()));
   } else {
-    SimutilCommandRunner().run(arguments);
+    await SimutilCommandRunner().run(arguments);
   }
+}
+
+Future<void> _runTuiSupervisor() async {
+  final ttyState = await _captureTerminalState();
+  try {
+    final child = await Process.start(
+      _currentExecutableCommand(),
+      _currentExecutableArguments(),
+      mode: ProcessStartMode.inheritStdio,
+      environment: {...Platform.environment, _tuiChildEnvVar: '1'},
+    );
+    exitCode = await child.exitCode;
+  } finally {
+    await _restoreTerminalState(ttyState);
+  }
+}
+
+String _currentExecutableCommand() {
+  final scriptPath = Platform.script.toFilePath();
+  if (scriptPath.endsWith('.dart')) {
+    return Platform.resolvedExecutable;
+  }
+  return '/proc/self/exe';
+}
+
+List<String> _currentExecutableArguments() {
+  final scriptPath = Platform.script.toFilePath();
+  if (scriptPath.endsWith('.dart')) {
+    return [...Platform.executableArguments, scriptPath];
+  }
+  return const [];
+}
+
+Future<String?> _captureTerminalState() async {
+  try {
+    if (!stdin.hasTerminal || !(Platform.isLinux || Platform.isMacOS)) {
+      return null;
+    }
+    final result = await _runStty(['-g']);
+    if (result.exitCode != 0) return null;
+
+    final state = (result.stdout as String).trim();
+    return state.isEmpty ? null : state;
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> _restoreTerminalState(String? ttyState) async {
+  try {
+    if (!stdin.hasTerminal || !(Platform.isLinux || Platform.isMacOS)) return;
+    // Restore the exact pre-TUI termios state from the parent process after the
+    // child TUI exits. On SSH PTYs this is more reliable than in-process
+    // restoration from the TUI itself.
+    if (ttyState != null) {
+      await _runStty([ttyState]);
+    } else {
+      await _runStty(['sane']);
+    }
+    await _restoreTerminalScreenState();
+  } catch (_) {}
+}
+
+Future<ProcessResult> _runStty(List<String> arguments) {
+  final ttyFlag = Platform.isMacOS ? '-f' : '-F';
+  return Process.run('stty', [ttyFlag, '/dev/tty', ...arguments]);
+}
+
+Future<void> _restoreTerminalScreenState() async {
+  final shell = Platform.environment['SHELL'] ?? '/bin/sh';
+  final term = Platform.environment['TERM'];
+
+  if (term != null && term.isNotEmpty) {
+    await Process.run('tput', ['rmcup']);
+    await Process.run('tput', ['cnorm']);
+    await Process.run('tput', ['sgr0']);
+  }
+
+  await Process.run(shell, [
+    '-lc',
+    "printf '\\033[?1049l\\033[?25h\\033[0m\\r' > /dev/tty",
+  ]);
 }

--- a/lib/services/android_device_service.dart
+++ b/lib/services/android_device_service.dart
@@ -11,37 +11,62 @@ import 'package:simutil/services/command_exec.dart';
 import 'package:simutil/services/device_service.dart';
 
 class AndroidDeviceService implements DeviceService {
-  AndroidDeviceService(this._exec, {String? androidHomeOverride})
-    : _androidHomeOverride = androidHomeOverride;
+  AndroidDeviceService(
+    this._exec, {
+    String? androidHomeOverride,
+    Map<String, String>? environment,
+    bool Function(String path)? fileExists,
+  }) : _androidHomeOverride = androidHomeOverride,
+       _environment = environment,
+       _fileExists = fileExists;
 
   static const Duration _deviceListTimeout = Duration(seconds: 15);
 
   final CommandExec _exec;
-
   final String? _androidHomeOverride;
+  final Map<String, String>? _environment;
+  final bool Function(String path)? _fileExists;
 
-  bool get _hasSdkAdb => File(adbPath).existsSync();
+  Map<String, String> get _env => _environment ?? Platform.environment;
 
-  bool get _hasSdkEmulator => File(emulatorPath).existsSync();
+  bool _pathExists(String path) =>
+      _fileExists?.call(path) ?? File(path).existsSync();
+
+  bool get _hasSdkAdb => _pathExists('${getAndroidHome()}/platform-tools/adb');
+
+  bool get _hasAdb => adbPath == 'adb' || _pathExists(adbPath);
+
+  bool get _hasSdkEmulator => _pathExists(emulatorPath);
 
   String getAndroidHome() {
     final override = _androidHomeOverride;
     if (override != null && override.isNotEmpty) return override;
-    final env =
-        Platform.environment['ANDROID_HOME'] ??
-        Platform.environment['ANDROID_SDK_ROOT'];
+
+    final env = _env['ANDROID_HOME'] ?? _env['ANDROID_SDK_ROOT'];
     if (env != null && env.isNotEmpty) return env;
-    final home = Platform.environment['HOME'] ?? '';
+
+    final home = _env['HOME'] ?? '';
+    if (Platform.isLinux) return '$home/Android/Sdk';
     return '$home/Library/Android/sdk';
   }
 
-  String get adbPath => '${getAndroidHome()}/platform-tools/adb';
+  String get adbPath {
+    final envAndroidHome = _env['ANDROID_HOME'] ?? _env['ANDROID_SDK_ROOT'];
+    if (envAndroidHome != null && envAndroidHome.isNotEmpty) {
+      return '$envAndroidHome/platform-tools/adb';
+    }
+
+    final sdkAdbPath = '${getAndroidHome()}/platform-tools/adb';
+    if (_pathExists(sdkAdbPath)) return sdkAdbPath;
+
+    return 'adb';
+  }
 
   String get emulatorPath => '${getAndroidHome()}/emulator/emulator';
 
   @override
   Future<bool> isAvailable() async {
-    if (!_hasSdkAdb || !_hasSdkEmulator) return false;
+    if (!_hasAdb || !_hasSdkEmulator) return false;
     try {
       final adbOk = await _exec.run(adbPath, arguments: ['version']);
       final emuOk = await _exec.run(emulatorPath, arguments: ['-list-avds']);
@@ -92,7 +117,7 @@ class AndroidDeviceService implements DeviceService {
   }
 
   Future<Map<String, String>> _getRunningAvdMap() async {
-    if (!_hasSdkAdb) return {};
+    if (!_hasAdb) return {};
 
     try {
       final result = await _exec.run(
@@ -289,6 +314,7 @@ class AndroidDeviceService implements DeviceService {
           .map((line) {
             final parts = line.split(RegExp(r'\s+'));
             final id = parts.isNotEmpty ? parts.first : '';
+            final adbState = parts.length > 1 ? parts[1] : '';
 
             var name = id;
             for (final part in parts) {
@@ -302,7 +328,14 @@ class AndroidDeviceService implements DeviceService {
               id: id,
               name: name,
               type: DeviceType.physical,
-              state: DeviceState.booted,
+              state: switch (adbState) {
+                'device' => DeviceState.booted,
+                'unauthorized' ||
+                'offline' ||
+                'recovery' ||
+                'sideload' => DeviceState.booting,
+                _ => DeviceState.shutdown,
+              },
             );
           })
           .where((d) => d.id.isNotEmpty)

--- a/lib/services/android_device_service.dart
+++ b/lib/services/android_device_service.dart
@@ -21,6 +21,7 @@ class AndroidDeviceService implements DeviceService {
        _fileExists = fileExists;
 
   static const Duration _deviceListTimeout = Duration(seconds: 15);
+  static final RegExp _physicalDeviceIdPattern = RegExp(r'^[A-Za-z0-9._:-]+$');
 
   final CommandExec _exec;
   final String? _androidHomeOverride;
@@ -306,9 +307,18 @@ class AndroidDeviceService implements DeviceService {
 
       final rawDevices = stdout
           .split('\n')
-          .skip(1)
           .map((l) => l.trim())
-          .where((l) => l.isNotEmpty && !l.startsWith('emulator-'));
+          .where((l) => l.isNotEmpty)
+          .where((l) => l != 'List of devices attached')
+          .where((l) => !l.startsWith('*'))
+          .where((l) => !l.startsWith('daemon'))
+          .where((l) => !l.startsWith('adb-'))
+          .where((l) => !l.startsWith('emulator-'))
+          .where((l) {
+            final parts = l.split(RegExp(r'\s+'));
+            return parts.length >= 2 &&
+                _physicalDeviceIdPattern.hasMatch(parts.first);
+          });
 
       return rawDevices
           .map((line) {

--- a/lib/simutil_app.dart
+++ b/lib/simutil_app.dart
@@ -357,6 +357,9 @@ class _SimutilAppState extends State<SimutilApp> {
         _openSettingsFile();
         return true;
       case LogicalKey.keyQ:
+        // On Linux/SSH we restore the terminal from a parent supervisor process
+        // after the TUI child exits, so here we want the child to terminate
+        // promptly instead of only stopping the Nocterm event loop.
         shutdownApp();
         return true;
       default:

--- a/test/services/android_device_service_test.dart
+++ b/test/services/android_device_service_test.dart
@@ -39,6 +39,38 @@ void main() {
       expect(svc.adbPath, adbPath);
       expect(svc.emulatorPath, emulatorPath);
     });
+
+    test('prefers ANDROID_HOME when set', () {
+      final svc = AndroidDeviceService(
+        FakeCommandExec((_, _) => null),
+        environment: {'ANDROID_HOME': '/opt/android-sdk', 'HOME': '/home/test'},
+      );
+
+      expect(svc.getAndroidHome(), '/opt/android-sdk');
+      expect(svc.adbPath, '/opt/android-sdk/platform-tools/adb');
+    });
+
+    test('falls back to Linux SDK path when adb exists there', () {
+      final svc = AndroidDeviceService(
+        FakeCommandExec((_, _) => null),
+        environment: {'HOME': '/home/test'},
+        fileExists: (path) =>
+            path == '/home/test/Android/Sdk/platform-tools/adb',
+      );
+
+      expect(svc.getAndroidHome(), '/home/test/Android/Sdk');
+      expect(svc.adbPath, '/home/test/Android/Sdk/platform-tools/adb');
+    });
+
+    test('falls back to adb on PATH when SDK adb is missing', () {
+      final svc = AndroidDeviceService(
+        FakeCommandExec((_, _) => null),
+        environment: {'HOME': '/home/test'},
+        fileExists: (_) => false,
+      );
+
+      expect(svc.adbPath, 'adb');
+    });
   });
 
   group('getSimulators', () {
@@ -52,7 +84,9 @@ void main() {
             'List of devices attached\nemulator-5554\tdevice\n',
           );
         }
-        if (command == adbPath && args.contains('avd') && args.contains('name')) {
+        if (command == adbPath &&
+            args.contains('avd') &&
+            args.contains('name')) {
           return FakeCommandExec.ok('Pixel_7\nOK\n');
         }
         return null;
@@ -98,6 +132,32 @@ void main() {
       expect(devices.single.name, 'Pixel 6a');
       expect(devices.single.type, DeviceType.physical);
       expect(devices.single.state, DeviceState.booted);
+    });
+
+    test('maps non-ready adb states to booting', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == adbPath && args.join(' ') == 'devices -l') {
+          return FakeCommandExec.ok(
+            'List of devices attached\n'
+            'ABC123 device product:foo model:Pixel_8 device:husky\n'
+            'DEF456 unauthorized\n'
+            'GHI789 offline\n'
+            'JKL012 recovery\n'
+            'MNO345 sideload\n',
+          );
+        }
+        return null;
+      });
+
+      final devices = await service(exec).getPhysicalDevices();
+
+      expect(devices, hasLength(5));
+      expect(devices[0].name, 'Pixel 8');
+      expect(devices[0].state, DeviceState.booted);
+      expect(devices[1].state, DeviceState.booting);
+      expect(devices[2].state, DeviceState.booting);
+      expect(devices[3].state, DeviceState.booting);
+      expect(devices[4].state, DeviceState.booting);
     });
   });
 
@@ -249,10 +309,9 @@ void main() {
     test('prefixes the avd id with @ and appends extra args', () async {
       final exec = FakeCommandExec((_, _) => FakeCommandExec.ok());
 
-      await service(exec).launchDevice(
-        deviceId: 'Pixel_7',
-        additionalArgs: ['-no-audio'],
-      );
+      await service(
+        exec,
+      ).launchDevice(deviceId: 'Pixel_7', additionalArgs: ['-no-audio']);
 
       expect(exec.calls.single.command, emulatorPath);
       expect(exec.calls.single.arguments, ['@Pixel_7', '-no-audio']);
@@ -263,9 +322,9 @@ void main() {
     test('issues emu kill and mirrors success', () async {
       final exec = FakeCommandExec((_, _) => FakeCommandExec.ok());
 
-      final result = await service(exec).shutdownSimulator(
-        deviceId: 'emulator-5554',
-      );
+      final result = await service(
+        exec,
+      ).shutdownSimulator(deviceId: 'emulator-5554');
 
       expect(result, isTrue);
       expect(exec.calls.single.arguments, [


### PR DESCRIPTION
## Summary

This PR fixes two Linux issues in simutil:

1. Android ADB discovery now works when `adb` is installed on `PATH`, such as `/usr/bin/adb`, without requiring a fake `~/Library/Android/sdk/platform-tools/adb` path.
2. Terminal cleanup now restores the terminal correctly for Linux SSH sessions when quitting simutil with `q`.

## Changes

### Android ADB discovery
- preserve existing behavior when `ANDROID_HOME` or `ANDROID_SDK_ROOT` is set
- add Linux SDK fallback: `~/Android/Sdk`
- fall back to `adb` on `PATH` when no SDK `adb` binary exists
- keep emulator lookup SDK-based
- improve physical device parsing so adb states like `unauthorized`, `offline`, `recovery`, and `sideload` are not treated as fully booted

### Terminal cleanup over SSH
- run the Linux TUI under a parent supervisor process
- snapshot tty state before launch
- restore tty and screen state from the parent after the TUI child exits
- keep `q` on `shutdownApp()` so the child exits promptly and the parent restore path runs reliably

## Root cause

On Linux systems without Android SDK environment variables, simutil assumed a macOS-style SDK path and built a broken ADB path even when `adb` was already installed on `PATH`.

For SSH terminal sessions, the TUI process could leave the PTY in a bad state on exit. Restoring terminal state from the parent process after the child exits proved more reliable than relying only on in-process cleanup.

## Validation

- `dart analyze --fatal-infos`
- `dart test`

## Notes

The terminal cleanup issue was debugged against a headless Linux Mint machine accessed over SSH from iTerm on macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android device discovery so the app now better handles SDK path detection and falls back more reliably when ADB isn’t available in the expected location.
  * Fixed physical device status reporting so unauthorized, offline, and similar devices are no longer treated as fully ready.
  * Restored terminal state cleanup after exiting remote/Linux TUI sessions, helping prevent broken shell behavior after quit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->