### PR TITLE
Fix refresh hang when device discovery returns empty results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent device refresh from hanging forever when a simulator or device lookup stalls.
+
 ## [0.5.0] - 2026-05-02
 
 ### Changed

--- a/lib/models/isolate_message.dart
+++ b/lib/models/isolate_message.dart
@@ -7,6 +7,7 @@ class IsolateRequest {
     required this.executable,
     this.arguments = const [],
     this.workingDirectory,
+    this.timeoutMs,
   });
 
   final int id;
@@ -14,6 +15,7 @@ class IsolateRequest {
   final String executable;
   final List<String> arguments;
   final String? workingDirectory;
+  final int? timeoutMs;
 }
 
 class IsolateResponse {

--- a/lib/services/android_device_service.dart
+++ b/lib/services/android_device_service.dart
@@ -11,9 +11,15 @@ import 'package:simutil/services/command_exec.dart';
 import 'package:simutil/services/device_service.dart';
 
 class AndroidDeviceService implements DeviceService {
-  const AndroidDeviceService(this._exec);
+  AndroidDeviceService(this._exec);
+
+  static const Duration _deviceListTimeout = Duration(seconds: 15);
 
   final CommandExec _exec;
+
+  bool get _hasSdkAdb => File(adbPath).existsSync();
+
+  bool get _hasSdkEmulator => File(emulatorPath).existsSync();
 
   String getAndroidHome() {
     final env =
@@ -30,6 +36,7 @@ class AndroidDeviceService implements DeviceService {
 
   @override
   Future<bool> isAvailable() async {
+    if (!_hasSdkAdb || !_hasSdkEmulator) return false;
     try {
       final adbOk = await _exec.run(adbPath, arguments: ['version']);
       final emuOk = await _exec.run(emulatorPath, arguments: ['-list-avds']);
@@ -43,8 +50,14 @@ class AndroidDeviceService implements DeviceService {
   Future<List<Device>> getSimulators() => _listEmulators();
 
   Future<List<Device>> _listEmulators() async {
+    if (!_hasSdkEmulator) return [];
+
     try {
-      final result = await _exec.run(emulatorPath, arguments: ['-list-avds']);
+      final result = await _exec.run(
+        emulatorPath,
+        arguments: ['-list-avds'],
+        timeout: _deviceListTimeout,
+      );
       if (!result.success) return [];
 
       final avdNames = result.stdout
@@ -74,8 +87,14 @@ class AndroidDeviceService implements DeviceService {
   }
 
   Future<Map<String, String>> _getRunningAvdMap() async {
+    if (!_hasSdkAdb) return {};
+
     try {
-      final result = await _exec.run(adbPath, arguments: ['devices']);
+      final result = await _exec.run(
+        adbPath,
+        arguments: ['devices'],
+        timeout: _deviceListTimeout,
+      );
       if (!result.success) return {};
 
       final serials = result.stdout
@@ -95,6 +114,7 @@ class AndroidDeviceService implements DeviceService {
             final nameResult = await _exec.run(
               adbPath,
               arguments: ['-s', serial, 'emu', 'avd', 'name'],
+              timeout: _deviceListTimeout,
             );
             if (nameResult.success) {
               final name = nameResult.stdout.split('\n').first.trim();
@@ -245,7 +265,11 @@ class AndroidDeviceService implements DeviceService {
   @override
   Future<List<Device>> getPhysicalDevices() async {
     try {
-      final result = await _exec.run(adbPath, arguments: ['devices', '-l']);
+      final result = await _exec.run(
+        adbPath,
+        arguments: ['devices', '-l'],
+        timeout: _deviceListTimeout,
+      );
       if (!result.success) return [];
 
       final stdout = result.stdout;

--- a/lib/services/command_exec.dart
+++ b/lib/services/command_exec.dart
@@ -20,22 +20,26 @@ abstract class CommandExec {
     String command, {
     List<String> arguments,
     String? workingDirectory,
+    Duration? timeout,
   });
 }
 
 class CommandExecImpl implements CommandExec {
-  
   @override
   Future<CommandResult> run(
     String command, {
     List<String> arguments = const [],
     String? workingDirectory,
+    Duration? timeout,
   }) async {
-    final result = await Process.run(
+    final resultFuture = Process.run(
       command,
       arguments,
       workingDirectory: workingDirectory,
     );
+    final result = timeout == null
+        ? await resultFuture
+        : await resultFuture.timeout(timeout);
     return CommandResult(
       stdout: result.stdout as String,
       stderr: result.stderr as String,
@@ -54,11 +58,13 @@ class IsolateCommandExec implements CommandExec {
     String command, {
     List<String> arguments = const [],
     String? workingDirectory,
+    Duration? timeout,
   }) {
     return _runner.execute(
       command,
       arguments,
       workingDirectory: workingDirectory,
+      timeout: timeout,
     );
   }
 }

--- a/lib/services/isolate_runner.dart
+++ b/lib/services/isolate_runner.dart
@@ -39,6 +39,7 @@ class IsolateRunner {
     String executable,
     List<String> arguments, {
     String? workingDirectory,
+    Duration? timeout,
   }) {
     assert(isReady, 'IsolateRunner.init() must be called before execute()');
 
@@ -53,6 +54,7 @@ class IsolateRunner {
         executable: executable,
         arguments: arguments,
         workingDirectory: workingDirectory,
+        timeoutMs: timeout?.inMilliseconds,
       ),
     );
 
@@ -117,18 +119,40 @@ class IsolateRunner {
       }
 
       try {
-        final result = await Process.run(
+        final process = await Process.start(
           message.executable,
           message.arguments,
           workingDirectory: message.workingDirectory,
         );
+        final stdoutFuture = process.stdout
+            .transform(SystemEncoding().decoder)
+            .join();
+        final stderrFuture = process.stderr
+            .transform(SystemEncoding().decoder)
+            .join();
+        final timeout = message.timeoutMs == null
+            ? null
+            : Duration(milliseconds: message.timeoutMs!);
+        final exitCode = timeout == null
+            ? await process.exitCode
+            : await process.exitCode.timeout(
+                timeout,
+                onTimeout: () {
+                  process.kill(ProcessSignal.sigkill);
+                  throw TimeoutException(
+                    'Command timed out after ${timeout.inSeconds} seconds',
+                  );
+                },
+              );
+        final stdout = await stdoutFuture;
+        final stderr = await stderrFuture;
 
         mainSendPort.send(
           IsolateResponse(
             id: message.id,
-            stdout: result.stdout as String,
-            stderr: result.stderr as String,
-            exitCode: result.exitCode,
+            stdout: stdout,
+            stderr: stderr,
+            exitCode: exitCode,
           ),
         );
       } catch (e) {

--- a/lib/simutil_app.dart
+++ b/lib/simutil_app.dart
@@ -31,6 +31,8 @@ class SimutilApp extends StatefulComponent {
 }
 
 class _SimutilAppState extends State<SimutilApp> {
+  static const _refreshTimeout = Duration(seconds: 15);
+
   final _di = ServiceLocator.instance;
 
   AppSettings _settings = const AppSettings();
@@ -116,35 +118,41 @@ class _SimutilAppState extends State<SimutilApp> {
     }
 
     try {
-      final results = await Future.wait([
-        _di.adbService.getPhysicalDevices().catchError((e, st) {
-          log('Failed to load Android devices: $e');
-          return <Device>[];
-        }),
-        _di.adbService.getSimulators().catchError((e, st) {
-          log('Failed to load Android emulators: $e');
-          return <Device>[];
-        }),
-        _di.simctlService.getSimulators().catchError((e, st) {
-          log('Failed to load iOS simulators: $e');
-          return <Device>[];
-        }),
-        _di.simctlService.getPhysicalDevices().catchError((e, st) {
-          log('Failed to load iOS devices: $e');
-          return <Device>[];
-        }),
-      ]);
+      final shouldLoadIos = Platform.isMacOS;
+      final androidDevices = await _loadDevicesWithTimeout(
+        label: 'Android devices',
+        silent: silent,
+        loader: _di.adbService.getPhysicalDevices,
+      );
+      final androidEmulators = await _loadDevicesWithTimeout(
+        label: 'Android emulators',
+        silent: silent,
+        loader: _di.adbService.getSimulators,
+      );
+      final iosSimulators = shouldLoadIos
+          ? await _loadDevicesWithTimeout(
+              label: 'iOS simulators',
+              silent: silent,
+              loader: _di.simctlService.getSimulators,
+            )
+          : <Device>[];
+      final iosDevices = shouldLoadIos
+          ? await _loadDevicesWithTimeout(
+              label: 'iOS devices',
+              silent: silent,
+              loader: _di.simctlService.getPhysicalDevices,
+            )
+          : <Device>[];
 
       setState(() {
-        _androidDevices = results[0];
-        _androidEmulators = results[1];
-        _iosSimulators = results[2];
-        _iosDevices = results[3];
+        _androidDevices = androidDevices;
+        _androidEmulators = androidEmulators;
+        _iosSimulators = iosSimulators;
+        _iosDevices = iosDevices;
         _loadingAndroidDevices = false;
         _loadingAndroidEmulators = false;
         _loadingIosSimulators = false;
         _loadingIosDevices = false;
-
         // Make sure index in range
         _androidDeviceSelectedIndex = _androidDevices.isEmpty
             ? 0
@@ -161,9 +169,6 @@ class _SimutilAppState extends State<SimutilApp> {
         _iosSimulatorSelectedIndex = _iosSimulators.isEmpty
             ? 0
             : _iosSimulatorSelectedIndex.clamp(0, _iosSimulators.length - 1);
-
-        _statusMessage = _buildIdleStatusMessage();
-
         // By default always keep focus on simulators / emulator list
         final hasAndroidDevices = _androidDevices.isNotEmpty;
         final hasIosDevices = _iosDevices.isNotEmpty;
@@ -187,9 +192,42 @@ class _SimutilAppState extends State<SimutilApp> {
           if (hasIosDevices) 'ios',
           'ios-simulators',
         ];
+
+        _statusMessage = _buildIdleStatusMessage();
       });
     } finally {
       _isRefreshing = false;
+    }
+  }
+
+  Future<List<Device>> _loadDevicesWithTimeout({
+    required String label,
+    required bool silent,
+    required Future<List<Device>> Function() loader,
+  }) async {
+    try {
+      if (!silent) {
+        setState(() {
+          _statusMessage = 'Refreshing $label...';
+        });
+      }
+      return await loader().timeout(_refreshTimeout);
+    } on TimeoutException {
+      log('Timed out while loading $label after $_refreshTimeout');
+      if (!silent) {
+        setState(() {
+          _statusMessage = 'Timed out while refreshing $label';
+        });
+      }
+      return <Device>[];
+    } catch (e, st) {
+      log('Failed to load $label: $e\n$st');
+      if (!silent) {
+        setState(() {
+          _statusMessage = 'Failed to refresh $label';
+        });
+      }
+      return <Device>[];
     }
   }
 
@@ -204,6 +242,9 @@ class _SimutilAppState extends State<SimutilApp> {
   }
 
   String _buildIdleStatusMessageForIosSimulators() {
+    if (_iosSimulators.isEmpty) {
+      return 'ADB Tools: n | Refresh: r | Switch: <tab> | Quit: q';
+    }
     final device = _iosSimulators[_iosSimulatorSelectedIndex];
     final parts = <String>[
       'Launch: <space> or <enter>',
@@ -227,6 +268,9 @@ class _SimutilAppState extends State<SimutilApp> {
   }
 
   String _buildIdleStatusMessageForAndroidEmulators() {
+    if (_androidEmulators.isEmpty) {
+      return 'ADB Tools: n | Refresh: r | Switch: <tab> | Quit: q';
+    }
     final device = _androidEmulators[_androidEmulatorSelectedIndex];
     final parts = <String>[
       'Launch: <space>',


### PR DESCRIPTION
## Summary

This PR fixes a refresh hang where pressing `r` could leave simutil stuck in refresh forever instead of returning to the normal idle state.

This PR is intentionally separate from #27.

- #27 covers Linux ADB discovery and SSH terminal cleanup
- this PR only covers the refresh hang so review stays focused and the fixes can be merged independently

## What changed

- add command-level timeout support through the command/isolate execution path
- apply refresh-timeout protection to Android discovery commands used during refresh
- skip iOS refresh work entirely on non-macOS platforms
- fail fast when Android emulator SDK binaries are not present instead of trying to refresh them anyway
- guard idle-status generation so empty emulator/simulator lists do not wedge refresh finalization

## Root cause

There turned out to be a few issues combining here:

- refresh waited on external device discovery commands that could stall
- Linux still walked through refresh paths that were only meaningful on macOS
- refresh finalization could try to build idle status text from empty emulator/simulator lists, which could leave the UI stuck after pressing `r`

## User impact

On Linux, especially in the headless/SSH workflow used for testing here, pressing `r` now returns control to the UI instead of hanging indefinitely when there are no refreshable iOS resources or no valid Android emulator binaries present.

## Validation

- `dart analyze --fatal-infos`
- `dart test`

## Notes

This was tested in the same Linux Mint over SSH setup that exposed the earlier terminal cleanup issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved device refresh hanging indefinitely when simulator or device lookup stalls by implementing timeout protection on device detection and enumeration operations.

## Improvements
* Enhanced detection of Android SDK tools availability to gracefully handle missing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->