### PR TITLE
ci: update test cli to gh actions and support x64 linux

### DIFF
--- a/.github/homebrew/simutil.rb.template
+++ b/.github/homebrew/simutil.rb.template
@@ -27,7 +27,18 @@ class Simutil < Formula
     end
   end
 
+  on_linux do
+    depends_on arch: :x86_64
+
+    url "https://github.com/dungngminh/simutil/releases/download/v{{VERSION}}/simutil-linux-x64.tar.gz"
+    sha256 "{{LINUX_X64_SHA256}}"
+
+    def install
+      bin.install "simutil-linux-x64" => "simutil"
+    end
+  end
+
   test do
-    assert_match "simutil", shell_output("#{bin}/simutil --version", 2)
+    assert_match "Simutil v#{version}", shell_output("#{bin}/simutil version")
   end
 end

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,31 @@ jobs:
       - name: Install dependencies
         run: dart pub get
 
+      - name: Run build_runner
+        run: dart run build_runner build --delete-conflicting-outputs
+
       - name: Build executable
         run: dart compile exe bin/simutil.dart -o ${{ matrix.artifact }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+
+      - name: Install binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          cp "${{ matrix.artifact }}" "$HOME/.local/bin/simutil"
+          chmod +x "$HOME/.local/bin/simutil"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:LOCALAPPDATA "simutil"
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          Copy-Item -Path "${{ matrix.artifact }}.exe" -Destination (Join-Path $installDir "simutil.exe") -Force
+          Add-Content -Path $env:GITHUB_PATH -Value $installDir
+
+      - name: Verify installed binary
+        run: simutil version
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-homebrew.yaml
+++ b/.github/workflows/deploy-homebrew.yaml
@@ -27,12 +27,16 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           # Download macOS ARM64 artifact and get SHA256
-          curl -sL "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/simutil-macos-arm64.tar.gz" -o macos-arm64.tar.gz
+          curl -fsL "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/simutil-macos-arm64.tar.gz" -o macos-arm64.tar.gz
           ARM64_SHA=$(sha256sum macos-arm64.tar.gz | cut -d ' ' -f 1)
 
           # Download macOS x64 artifact and get SHA256
-          curl -sL "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/simutil-macos-x64.tar.gz" -o macos-x64.tar.gz
+          curl --fail -sL "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/simutil-macos-x64.tar.gz" -o macos-x64.tar.gz
           X64_SHA=$(sha256sum macos-x64.tar.gz | cut -d ' ' -f 1)
+
+          # Download Linux x64 artifact and get SHA256
+          curl --fail -sL "https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/simutil-linux-x64.tar.gz" -o linux-x64.tar.gz
+          LINUX_X64_SHA=$(sha256sum linux-x64.tar.gz | cut -d ' ' -f 1)
 
           # Generate formula from template
           mkdir -p homebrew-tap/Formula
@@ -40,6 +44,7 @@ jobs:
           sed -i "s/{{VERSION}}/$VERSION/g" homebrew-tap/Formula/simutil.rb
           sed -i "s/{{ARM64_SHA256}}/$ARM64_SHA/g" homebrew-tap/Formula/simutil.rb
           sed -i "s/{{X64_SHA256}}/$X64_SHA/g" homebrew-tap/Formula/simutil.rb
+          sed -i "s/{{LINUX_X64_SHA256}}/$LINUX_X64_SHA/g" homebrew-tap/Formula/simutil.rb
 
       - name: Commit and push formula
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,9 +63,61 @@ jobs:
           name: simutil-${{ matrix.target }}
           path: simutil-${{ matrix.target }}.${{ runner.os == 'Windows' && 'zip' || 'tar.gz' }}
 
+  test-install:
+    name: Test Install ${{ matrix.target }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            archive: simutil-linux-x64.tar.gz
+            binary: simutil-linux-x64
+          - os: macos-15-intel
+            target: macos-x64
+            archive: simutil-macos-x64.tar.gz
+            binary: simutil-macos-x64
+          - os: macos-14
+            target: macos-arm64
+            archive: simutil-macos-arm64.tar.gz
+            binary: simutil-macos-arm64
+          - os: windows-latest
+            target: windows-x64
+            archive: simutil-windows-x64.zip
+            binary: simutil-windows-x64.exe
+    steps:
+      - name: Download archive
+        uses: actions/download-artifact@v4
+        with:
+          name: simutil-${{ matrix.target }}
+          path: dist
+
+      - name: Install archive (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf "dist/${{ matrix.archive }}" -C "$HOME/.local/bin"
+          mv "$HOME/.local/bin/${{ matrix.binary }}" "$HOME/.local/bin/simutil"
+          chmod +x "$HOME/.local/bin/simutil"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $installDir = Join-Path $env:LOCALAPPDATA "simutil"
+          New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+          Expand-Archive -Path "dist/${{ matrix.archive }}" -DestinationPath $installDir -Force
+          Move-Item -Path (Join-Path $installDir "${{ matrix.binary }}") -Destination (Join-Path $installDir "simutil.exe") -Force
+          Add-Content -Path $env:GITHUB_PATH -Value $installDir
+
+      - name: Verify installed binary
+        run: simutil version
+
   release:
     name: Create Release
-    needs: build
+    needs: test-install
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-07-08
+
+### Added
+
+- Add Linux x64 support to the generated Homebrew formula.
+- Add a release install smoke test that verifies packaged binaries before drafting a GitHub Release.
+
 ## [0.6.1] - 2026-07-07
 
 ### Fixed

--- a/docs/ai/deployment.md
+++ b/docs/ai/deployment.md
@@ -28,7 +28,8 @@ flowchart TD
 
     subgraph release [release.yaml]
         Build["build (matrix x4)"] --> Archive["tar.gz / zip"]
-        Archive --> Draft["Create Draft GitHub Release"]
+        Archive --> Install["test-install (matrix x4)"]
+        Install --> Draft["Create Draft GitHub Release"]
     end
     Release --> release
 
@@ -51,11 +52,13 @@ flowchart TD
 | `macos-14`      | `macos-arm64` | `simutil-macos-arm64.tar.gz`      |
 | `windows-latest`| `windows-x64` | `simutil-windows-x64.zip`         |
 
-Each runner: `dart pub get` → `dart run build_runner build --delete-conflicting-outputs`
+Each build runner: `dart pub get` → `dart run build_runner build --delete-conflicting-outputs`
 → `dart compile exe bin/simutil.dart -o <artifact>` → archive (`tar -czvf` on Unix,
-`Compress-Archive` on Windows). The `release` job downloads all artifacts,
-generates `checksums.txt` via `sha256sum`, and creates a **draft** GitHub
-Release with auto-generated notes (categorized per [.github/release.yaml](../../.github/release.yaml)).
+`Compress-Archive` on Windows). The `test-install` job downloads each archive,
+extracts it into a temporary install location, puts it on `PATH`, and runs
+`simutil version`. The `release` job then downloads all artifacts, generates
+`checksums.txt` via `sha256sum`, and creates a **draft** GitHub Release with
+auto-generated notes (categorized per [.github/release.yaml](../../.github/release.yaml)).
 
 ## Workflows in detail
 
@@ -64,6 +67,8 @@ Release with auto-generated notes (categorized per [.github/release.yaml](../../
 - **Trigger**: `push` of a tag matching `v*`.
 - **Output**: draft GitHub Release with four archives + `checksums.txt`.
 - **Secret**: `GH_PAT` (used by `softprops/action-gh-release@v2` to create the release).
+- Gates the draft release behind `test-install`, which verifies Linux, macOS
+  Intel, macOS Apple Silicon, and Windows archives can be installed and run.
 - The two `deploy-homebrew` / `deploy-winget` jobs at the bottom are intentionally
   commented out — Homebrew is wired to fire on `release: released` instead, and
   WinGet is manual.
@@ -82,10 +87,11 @@ Release with auto-generated notes (categorized per [.github/release.yaml](../../
 - **Trigger**: GitHub `release: released` (when a draft release is published) or
   `workflow_dispatch`.
 - Reads `${GITHUB_REF_NAME}` (e.g. `v0.4.1`) → `VERSION=0.4.1`.
-- Downloads the two macOS archives from the release, computes their `sha256`,
+- Downloads the macOS and Linux archives from the release, computes their `sha256`,
   renders [.github/homebrew/simutil.rb.template](../../.github/homebrew/simutil.rb.template)
-  with `{{VERSION}}`, `{{ARM64_SHA256}}`, `{{X64_SHA256}}`, and pushes
-  `Formula/simutil.rb` to the `dungngminh/homebrew-simutil` tap.
+  with `{{VERSION}}`, `{{ARM64_SHA256}}`, `{{X64_SHA256}}`,
+  `{{LINUX_X64_SHA256}}`, and pushes `Formula/simutil.rb` to the
+  `dungngminh/homebrew-simutil` tap.
 - **Secret**: `HOMEBREW_TAP_TOKEN` — a PAT with `contents: write` on the tap repo.
 
 ### deploy-winget.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simutil
 description: TUI application for launching Android Simulators / iOS Simulators and more ...
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/dungngminh/simutil
 
 environment:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Update release and Homebrew automation for SimUtil 0.6.2.

- Add Linux x64 support to the generated Homebrew formula.
- Add release install smoke tests for Linux, macOS Intel, macOS Apple Silicon, and Windows before drafting a GitHub Release.
- Update Homebrew deployment to publish Linux x64 checksums.
- Update deployment docs, README install wording, changelog, and package version.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🔥 New feature (non-breaking change which adds functionality)
- [x] ✨ Enhancement (non-breaking change which improves existing functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Code refactor
- [x] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 📦 Build configuration change
- [x] ✅ Test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux x64 support to the Homebrew formula for installing `simutil`.
  * Added an installation smoke test during the release workflow that verifies the packaged binary by running `simutil version`.
* **Bug Fixes**
  * Improved CI by installing the built binary locally and validating `simutil version` on all platforms.
  * Updated the Homebrew formula test to match the new expected version output.
* **Documentation**
  * Updated deployment documentation and the changelog to reflect the new release and packaging flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->