### PR TITLE
docs: clarify iOS simulator support is macOS-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Clarify in the README that iOS simulators and devices require macOS; Linux and Windows support Android only.
+
 ## [0.6.2] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 Browse your available emulators and simulators side-by-side, launch with custom options and connect to physical devices wirelessly.
 
+SimUtil runs on macOS, Linux, and Windows. **iOS Simulator support requires macOS** (Xcode / `simctl`); on Linux and Windows the TUI focuses on Android emulators and devices.
+
 Simutil is written with [Nocterm](https://nocterm.dev/), a terminal UI framework for Dart with similar syntax to Flutter.
 
 <p align="center">
@@ -126,9 +128,15 @@ simutil
 
 ## Supported platforms
 
-- [x] macOS
-- [x] Linux
-- [x] Windows
+SimUtil itself runs on macOS, Linux, and Windows. Feature support depends on the host OS:
+
+| Host OS | Android emulators & devices | iOS simulators & devices |
+| ------- | --------------------------- | ------------------------ |
+| macOS   | Yes                         | Yes (requires Xcode)     |
+| Linux   | Yes                         | No                       |
+| Windows | Yes                         | No                       |
+
+iOS support depends on Apple’s tools (`xcrun simctl` for simulators, `xcrun devicectl` for physical devices), which are only available on macOS. On Linux and Windows, the iOS panels indicate they are not supported; Android launch, ADB tools, Logcat, and plugins still work.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Clarifies platform support in the README so Linux/Windows users do not assume SimUtil can run iOS simulators on those hosts.

- Add an early note that **iOS Simulator support requires macOS** (Xcode / `simctl`)
- Replace the bare OS checklist with a host/feature matrix (Android vs iOS)
- Explain that non-macOS iOS panels are unsupported while Android tools still work
- Record the docs change under `[Unreleased]` in `CHANGELOG.md`

Closes #36

## Type of Change

- [ ] 🔥 New feature (non-breaking change which adds functionality)
- [ ] ✨ Enhancement (non-breaking change which improves existing functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Code refactor
- [x] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 📦 Build configuration change
- [ ] ✅ Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified platform compatibility: iOS simulators/devices require macOS, while Linux and Windows focus on Android.
  * Updated README with a host-to-feature support table and expanded guidance on iOS tooling requirements.
  * Added an Unreleased changelog note reflecting the same host-OS support changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->