### PR TITLE
feat: add Xcode Tools to clear Derived Data (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-21
+
+### Added
+
+- Add confirmation dialog.
+- Add Xcode Tools (`x`) with Clear Derived Data — measure size, confirm, then wipe `~/Library/Developer/Xcode/DerivedData` (macOS only).
+
+## Fixed
+
+- Fix background color of some dialogs.
+
 ## [0.7.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Simutil is written with [Nocterm](https://nocterm.dev/), a terminal UI framework
   - QR code pairing (Android 11+)
 - **Custom Plugins** — Add your own external tools (scrcpy, Maestro, etc.) via a YAML file, no code changes needed. Press `p` to pick a plugin and a command to run on the selected device.
 - **Edit Config** — Press `e` to open `~/.simutil/settings.yaml` in your default editor (macOS, Linux, Windows).
+- **Xcode Tools** — Press `x` (macOS) to clear Xcode Derived Data after a size preview and confirmation.
 
 ## Custom Plugins
 

--- a/lib/components/confirm_dialog.dart
+++ b/lib/components/confirm_dialog.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:simutil/components/show_overlay_dialog.dart';
+import 'package:simutil/components/simutil_theme.dart';
+
+/// A simple yes/no confirmation overlay.
+///
+/// Enter confirms; Escape cancels.
+class ConfirmDialog extends StatelessComponent {
+  const ConfirmDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String title;
+  final String message;
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Component build(BuildContext context) {
+    final st = context.simutilTheme;
+
+    return Center(
+      child: Focusable(
+        focused: true,
+        onKeyEvent: _handleKeyEvent,
+        child: Container(
+          margin: EdgeInsets.all(16),
+          decoration: st.dialogPanel(title),
+          child: Padding(
+            padding: EdgeInsets.all(1),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(' $message', style: st.body),
+                SizedBox(height: 1),
+                Divider(),
+                Text(' Confirm: <enter> | Cancel: <esc>', style: st.dimmed),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool _handleKeyEvent(KeyboardEvent event) {
+    if (event.logicalKey == LogicalKey.escape) {
+      onCancel();
+      return true;
+    }
+    if (event.logicalKey == LogicalKey.enter) {
+      onConfirm();
+      return true;
+    }
+    return false;
+  }
+}
+
+Future<bool> showConfirmDialog({
+  required BuildContext context,
+  required String title,
+  required String message,
+}) async {
+  final result = await showOverlayDialog<bool>(
+    context: context,
+    builder: (context, completer, entry) {
+      return ConfirmDialog(
+        title: title,
+        message: message,
+        onConfirm: () {
+          completer.complete(true);
+          entry?.remove();
+        },
+        onCancel: () {
+          completer.complete(false);
+          entry?.remove();
+        },
+      );
+    },
+  );
+  return result ?? false;
+}

--- a/lib/components/error_dialog.dart
+++ b/lib/components/error_dialog.dart
@@ -31,7 +31,6 @@ class ErrorDialog extends StatelessComponent {
           return false;
         },
         child: Container(
-          width: 100,
           margin: EdgeInsets.all(16),
           decoration: st.errorDialogPanel(title),
           child: Padding(

--- a/lib/components/simutil_theme.dart
+++ b/lib/components/simutil_theme.dart
@@ -78,6 +78,12 @@ class SimutilTheme {
     color: Color.defaultColor
   );
 
+  BoxDecoration successDialogPanel(String title) => BoxDecoration(
+    border: BoxBorder.all(style: BoxBorderStyle.rounded, color: success),
+    title: BorderTitle(text: title),
+    color: Color.defaultColor
+  );
+
   BoxDecoration errorDialogPanel(String title) => BoxDecoration(
     border: BoxBorder.all(style: BoxBorderStyle.rounded, color: error),
     title: BorderTitle(text: title),

--- a/lib/components/success_dialog.dart
+++ b/lib/components/success_dialog.dart
@@ -33,14 +33,7 @@ class SuccessDialog extends StatelessComponent {
         },
         child: Container(
           margin: EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            border: BoxBorder.all(
-              style: BoxBorderStyle.rounded,
-              color: st.success,
-            ),
-            title: BorderTitle(text: title),
-            color: st.background,
-          ),
+          decoration: st.successDialogPanel(title),
           child: Padding(
             padding: EdgeInsets.all(1),
             child: Column(

--- a/lib/plugins/xcode_tools/xcode_tools_dialog.dart
+++ b/lib/plugins/xcode_tools/xcode_tools_dialog.dart
@@ -1,0 +1,139 @@
+import 'dart:async';
+
+import 'package:nocterm/nocterm.dart';
+import 'package:simutil/components/show_overlay_dialog.dart';
+import 'package:simutil/components/simutil_icons.dart';
+import 'package:simutil/components/simutil_theme.dart';
+
+enum XcodeToolOption {
+  clearDerivedData(
+    label: 'Clear Derived Data',
+    description:
+        'Delete all of ~/Library/Developer/Xcode/DerivedData'
+  );
+
+  const XcodeToolOption({required this.label, required this.description});
+
+  final String label;
+  final String description;
+}
+
+class XcodeToolsDialog extends StatefulComponent {
+  const XcodeToolsDialog({
+    super.key,
+    required this.onSelect,
+    required this.onCancel,
+  });
+
+  final void Function(XcodeToolOption option) onSelect;
+  final VoidCallback onCancel;
+
+  @override
+  State<XcodeToolsDialog> createState() => _XcodeToolsDialogState();
+}
+
+class _XcodeToolsDialogState extends State<XcodeToolsDialog> {
+  int _selectedIndex = 0;
+
+  List<XcodeToolOption> get _options => XcodeToolOption.values;
+
+  @override
+  Component build(BuildContext context) {
+    final st = context.simutilTheme;
+
+    return Center(
+      child: Container(
+        color: st.background,
+        margin: EdgeInsets.all(16),
+        decoration: st.dialogPanel('Xcode Tools'),
+        child: Padding(
+          padding: EdgeInsets.all(1),
+          child: Focusable(
+            focused: true,
+            onKeyEvent: _handleKeyEvent,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ..._options.asMap().entries.map((entry) {
+                  return _buildOption(st, entry.key, entry.value);
+                }),
+                Divider(),
+                Text(
+                  ' Navigate: <↑/↓> | Select: <enter> | Cancel: <esc>',
+                  style: st.dimmed,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Component _buildOption(SimutilTheme st, int index, XcodeToolOption option) {
+    final isSelected = _selectedIndex == index;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Text(
+              isSelected ? ' ${SimutilIcons.pointer} ' : '   ',
+              style: st.label,
+            ),
+            Text(option.label, style: isSelected ? st.selected : st.bold),
+          ],
+        ),
+        Text('   ${option.description}', style: st.dimmed),
+        SizedBox(height: 1),
+      ],
+    );
+  }
+
+  bool _handleKeyEvent(KeyboardEvent event) {
+    if (event.logicalKey == LogicalKey.escape) {
+      component.onCancel();
+      return true;
+    }
+
+    if (event.logicalKey == LogicalKey.enter) {
+      component.onSelect(_options[_selectedIndex]);
+      return true;
+    }
+
+    if (event.logicalKey == LogicalKey.arrowUp) {
+      setState(() {
+        _selectedIndex = (_selectedIndex - 1).clamp(0, _options.length - 1);
+      });
+      return true;
+    }
+
+    if (event.logicalKey == LogicalKey.arrowDown) {
+      setState(() {
+        _selectedIndex = (_selectedIndex + 1).clamp(0, _options.length - 1);
+      });
+      return true;
+    }
+
+    return false;
+  }
+}
+
+Future<XcodeToolOption?> showXcodeToolsDialog(BuildContext context) =>
+    showOverlayDialog(
+      context: context,
+      builder: (context, completer, entry) {
+        return XcodeToolsDialog(
+          onSelect: (option) {
+            completer.complete(option);
+            entry?.remove();
+          },
+          onCancel: () {
+            completer.complete(null);
+            entry?.remove();
+          },
+        );
+      },
+    );

--- a/lib/services/service_locator.dart
+++ b/lib/services/service_locator.dart
@@ -7,6 +7,7 @@ import 'package:simutil/services/plugin_registry_service.dart';
 import 'package:simutil/services/plugin_runner_service.dart';
 import 'package:simutil/services/settings_service.dart';
 import 'package:simutil/services/wifi_discovery_service.dart';
+import 'package:simutil/services/xcode_cache_service.dart';
 
 class ServiceLocator {
   ServiceLocator._();
@@ -30,6 +31,9 @@ class ServiceLocator {
   late final PluginRegistryService pluginRegistry = PluginRegistryServiceImpl();
   late final PluginRunnerService pluginRunner =
       PluginRunnerServiceImpl(commandExec);
+  late final XcodeCacheService xcodeCacheService = XcodeCacheService(
+    commandExec,
+  );
 
   Future<void> init() async => isolateRunner.init();
 

--- a/lib/services/xcode_cache_service.dart
+++ b/lib/services/xcode_cache_service.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:simutil/services/command_exec.dart';
+import 'package:simutil/utils/int_extension.dart';
+
+/// Result of clearing Xcode Derived Data.
+class XcodeCacheClearResult {
+  const XcodeCacheClearResult({
+    required this.success,
+    required this.message,
+    this.freedBytes,
+  });
+
+  final bool success;
+  final String message;
+  final int? freedBytes;
+}
+
+/// Manages Xcode Derived Data at `~/Library/Developer/Xcode/DerivedData`.
+///
+/// All shell work goes through [CommandExec] so the TUI isolate stays free.
+/// Public APIs that touch the filesystem are macOS-only.
+class XcodeCacheService {
+  XcodeCacheService(this._exec, {String? homeDirectory})
+    : _homeDirectory = homeDirectory;
+
+  final CommandExec _exec;
+  final String? _homeDirectory;
+
+  /// Absolute path to Derived Data for [home] (or `$HOME` / user home).
+  static String derivedDataPathFor(String home) =>
+      '$home/Library/Developer/Xcode/DerivedData';
+
+  /// Default Derived Data path under the current user home.
+  String get derivedDataPath {
+    final home =
+        _homeDirectory ?? Platform.environment['HOME'] ?? Platform.pathSeparator;
+    return derivedDataPathFor(home);
+  }
+
+  /// Disk usage of Derived Data in bytes, or `null` if missing / unreadable.
+  Future<int?> getDerivedDataSizeBytes() async {
+    if (!Platform.isMacOS) return null;
+    final path = derivedDataPath;
+    try {
+      final result = await _exec.run('du', arguments: ['-sk', path]);
+      if (!result.success) return null;
+      final line = result.stdout.trim();
+      if (line.isEmpty) return null;
+      final kbToken = line.split(RegExp(r'\s+')).first;
+      final kb = int.tryParse(kbToken);
+      if (kb == null) return null;
+      return kb * 1024;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Deletes Derived Data and recreates an empty directory.
+  ///
+  /// When the folder is already missing, returns success with a soft message.
+  Future<XcodeCacheClearResult> clearDerivedData() async {
+    if (!Platform.isMacOS) {
+      return const XcodeCacheClearResult(
+        success: false,
+        message: 'Xcode Derived Data is only available on macOS',
+      );
+    }
+
+    final path = derivedDataPath;
+    final sizeBefore = await getDerivedDataSizeBytes();
+
+    try {
+      final rm = await _exec.run('rm', arguments: ['-rf', path]);
+      if (!rm.success) {
+        final detail = rm.stderr.trim().isNotEmpty
+            ? rm.stderr.trim()
+            : 'rm failed (exit ${rm.exitCode})';
+        return XcodeCacheClearResult(
+          success: false,
+          message: 'Failed to clear Derived Data: $detail',
+          freedBytes: sizeBefore,
+        );
+      }
+
+      final mkdir = await _exec.run('mkdir', arguments: ['-p', path]);
+      if (!mkdir.success) {
+        final detail = mkdir.stderr.trim().isNotEmpty
+            ? mkdir.stderr.trim()
+            : 'mkdir failed (exit ${mkdir.exitCode})';
+        return XcodeCacheClearResult(
+          success: false,
+          message:
+              'Derived Data was removed but the folder could not be recreated: $detail',
+          freedBytes: sizeBefore,
+        );
+      }
+
+      if (sizeBefore == null || sizeBefore == 0) {
+        return const XcodeCacheClearResult(
+          success: true,
+          message: 'Derived Data was already empty or missing',
+          freedBytes: 0,
+        );
+      }
+
+      return XcodeCacheClearResult(
+        success: true,
+        message: 'Cleared ${sizeBefore.formatBytes} of Derived Data',
+        freedBytes: sizeBefore,
+      );
+    } catch (e) {
+      return XcodeCacheClearResult(
+        success: false,
+        message: 'Failed to clear Derived Data: $e',
+        freedBytes: sizeBefore,
+      );
+    }
+  }
+}

--- a/lib/simutil_app.dart
+++ b/lib/simutil_app.dart
@@ -7,6 +7,7 @@ import 'package:simutil/components/android_launch_dialog.dart';
 import 'package:simutil/components/app_header.dart';
 import 'package:simutil/components/app_status_bar.dart';
 import 'package:simutil/components/changelog_dialog.dart';
+import 'package:simutil/components/confirm_dialog.dart';
 import 'package:simutil/components/device_detail_panel.dart';
 import 'package:simutil/components/device_list_component.dart';
 import 'package:simutil/components/error_dialog.dart';
@@ -26,8 +27,10 @@ import 'package:simutil/plugins/adb_tools/wireless_pairing/wireless_pairing_dial
 import 'package:simutil/plugins/logcat/logcat_dialog.dart';
 import 'package:simutil/plugins/registry/command_menu_dialog.dart';
 import 'package:simutil/plugins/registry/plugin_menu_dialog.dart';
+import 'package:simutil/plugins/xcode_tools/xcode_tools_dialog.dart';
 import 'package:simutil/services/service_locator.dart';
 import 'package:simutil/utils/constant.dart';
+import 'package:simutil/utils/int_extension.dart';
 import 'package:simutil/utils/version.dart';
 
 class SimutilApp extends StatefulComponent {
@@ -269,40 +272,54 @@ class _SimutilAppState extends State<SimutilApp> {
 
   String _buildIdleStatusMessageForIosSimulators() {
     if (_iosSimulators.isEmpty) {
-      return 'Edit config: e | ADB Tools: n | Refresh: r | Switch: <tab> | Quit: q';
+      return _joinStatusHints([
+        'Edit config: e',
+        'ADB Tools: n',
+        if (Platform.isMacOS) 'Xcode Tools: x',
+        'Refresh: r',
+        'Switch: <tab>',
+        'Quit: q',
+      ]);
     }
     final device = _iosSimulators[_iosSimulatorSelectedIndex];
-    final parts = <String>[
+    return _joinStatusHints([
       'Launch: <space> or <enter>',
       if (device.isRunning) 'Shutdown: t',
       'Plugins: p',
       'Edit config: e',
       'ADB Tools: n',
+      if (Platform.isMacOS) 'Xcode Tools: x',
       'Refresh: r',
       'Switch: <tab>',
       'Quit: q',
-    ];
-    return parts.join(' | ');
+    ]);
   }
 
   String _buildIdleStatusMessageForIos() {
-    final parts = <String>[
+    return _joinStatusHints([
       'Plugins: p',
       'Edit config: e',
       'ADB Tools: n',
+      if (Platform.isMacOS) 'Xcode Tools: x',
       'Refresh: r',
       'Switch: <tab>',
       'Quit: q',
-    ];
-    return parts.join(' | ');
+    ]);
   }
 
   String _buildIdleStatusMessageForAndroidEmulators() {
     if (_androidEmulators.isEmpty) {
-      return 'Edit config: e | ADB Tools: n | Refresh: r | Switch: <tab> | Quit: q';
+      return _joinStatusHints([
+        'Edit config: e',
+        'ADB Tools: n',
+        if (Platform.isMacOS) 'Xcode Tools: x',
+        'Refresh: r',
+        'Switch: <tab>',
+        'Quit: q',
+      ]);
     }
     final device = _androidEmulators[_androidEmulatorSelectedIndex];
-    final parts = <String>[
+    return _joinStatusHints([
       'Launch: <space>',
       'Launch with option: <enter>',
       if (device.isRunning) 'Shutdown: t',
@@ -310,25 +327,27 @@ class _SimutilAppState extends State<SimutilApp> {
       'Plugins: p',
       'Edit config: e',
       'ADB Tools: n',
+      if (Platform.isMacOS) 'Xcode Tools: x',
       'Refresh: r',
       'Switch: <tab>',
       'Quit: q',
-    ];
-    return parts.join(' | ');
+    ]);
   }
 
   String _buildIdleStatusMessageForAndroidDevices() {
-    final parts = <String>[
+    return _joinStatusHints([
       'Plugins: p',
       'Logcat: l',
       'Edit config: e',
       'ADB Tools: n',
+      if (Platform.isMacOS) 'Xcode Tools: x',
       'Refresh: r',
       'Switch: <tab>',
       'Quit: q',
-    ];
-    return parts.join(' | ');
+    ]);
   }
+
+  String _joinStatusHints(List<String> parts) => parts.join(' | ');
 
   Device? get _currentSelectedDevice {
     if (_focusKey == 'android' && _androidDevices.isNotEmpty) {
@@ -378,6 +397,10 @@ class _SimutilAppState extends State<SimutilApp> {
       case LogicalKey.keyE:
         _openSettingsFile();
         return true;
+      case LogicalKey.keyX:
+        if (!Platform.isMacOS) return false;
+        _showXcodeTools();
+        return true;
       case LogicalKey.keyQ:
         // On Linux/SSH we restore the terminal from a parent supervisor process
         // after the TUI child exits, so here we want the child to terminate
@@ -409,6 +432,65 @@ class _SimutilAppState extends State<SimutilApp> {
       case AdbToolOption.pairWithQrCode:
         await _handleQrConnect();
         break;
+    }
+  }
+
+  Future<void> _showXcodeTools() async {
+    // Only wired from the macOS key binding; keep a hard guard for safety.
+    if (!Platform.isMacOS) return;
+
+    final option = await showXcodeToolsDialog(context);
+    if (option == null) return;
+
+    switch (option) {
+      case XcodeToolOption.clearDerivedData:
+        await _clearDerivedData();
+    }
+  }
+
+  Future<void> _clearDerivedData() async {
+    final service = _di.xcodeCacheService;
+    final path = service.derivedDataPath;
+
+    setState(() => _statusMessage = 'Measuring Derived Data…');
+    final sizeBytes = await service.getDerivedDataSizeBytes();
+    final sizeLabel = sizeBytes == null ? 'unknown size' : sizeBytes.formatBytes;
+
+    if (!mounted) return;
+
+    final confirmed = await showConfirmDialog(
+      context: context,
+      title: 'Clear Derived Data',
+      message:
+          'Delete all of'
+          ' $path'
+          ' ($sizeLabel)\n\n'
+          ' Xcode may rebuild indexes on next open.\n'
+          ' Close Xcode first for the cleanest result.',
+    );
+    if (!confirmed) {
+      setState(() => _statusMessage = _buildIdleStatusMessage());
+      return;
+    }
+
+    setState(() => _statusMessage = 'Clearing Derived Data…');
+    final result = await service.clearDerivedData();
+    if (!mounted) return;
+
+    if (result.success) {
+      await showSuccessDialog(
+        context: context,
+        title: 'Derived Data Cleared',
+        message: result.message,
+      );
+      setState(() => _statusMessage = result.message);
+    } else {
+      await showErrorDialog(
+        context,
+        title: 'Clear Failed',
+        message: result.message,
+      );
+      setState(() => _statusMessage = 'Failed to clear Derived Data');
     }
   }
 

--- a/lib/utils/int_extension.dart
+++ b/lib/utils/int_extension.dart
@@ -1,0 +1,21 @@
+extension IntExtension on int {
+  /// Formats this value as a short human-readable byte size (e.g. `3.9G`, `512K`).
+  ///
+  /// Negative values are treated as `0`.
+  String get formatBytes {
+    var bytes = this;
+    if (bytes < 0) bytes = 0;
+    const units = ['B', 'K', 'M', 'G', 'T'];
+    var value = bytes.toDouble();
+    var unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024;
+      unitIndex++;
+    }
+    if (unitIndex == 0) return '${value.round()}B';
+    final fixed = value >= 10
+        ? value.toStringAsFixed(0)
+        : value.toStringAsFixed(1);
+    return '$fixed${units[unitIndex]}';
+  }
+}

--- a/lib/utils/version.dart
+++ b/lib/utils/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.7.0';
+const packageVersion = '0.8.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simutil
 description: TUI application for launching Android Simulators / iOS Simulators and more ...
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/dungngminh/simutil
 
 environment:

--- a/test/services/xcode_cache_service_test.dart
+++ b/test/services/xcode_cache_service_test.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:simutil/services/xcode_cache_service.dart';
+import 'package:simutil/utils/int_extension.dart';
+import 'package:test/test.dart';
+
+import 'fake_command_exec.dart';
+
+void main() {
+  group('XcodeCacheService.derivedDataPathFor', () {
+    test('builds path under home', () {
+      expect(
+        XcodeCacheService.derivedDataPathFor('/Users/dev'),
+        '/Users/dev/Library/Developer/Xcode/DerivedData',
+      );
+    });
+  });
+
+  group('XcodeCacheService.getDerivedDataSizeBytes', () {
+    test('parses du -sk output to bytes', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == 'du' && args.contains('-sk')) {
+          return FakeCommandExec.ok('3987456\t/Users/dev/Library/Developer/Xcode/DerivedData\n');
+        }
+        return null;
+      });
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) {
+        expect(await service.getDerivedDataSizeBytes(), isNull);
+        return;
+      }
+
+      final size = await service.getDerivedDataSizeBytes();
+      expect(size, 3987456 * 1024);
+      expect(exec.calls, hasLength(1));
+      expect(exec.calls.single.command, 'du');
+      expect(exec.calls.single.arguments, [
+        '-sk',
+        '/Users/dev/Library/Developer/Xcode/DerivedData',
+      ]);
+    });
+
+    test('returns null when du fails', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == 'du') return FakeCommandExec.fail('No such file');
+        return null;
+      });
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) {
+        expect(await service.getDerivedDataSizeBytes(), isNull);
+        return;
+      }
+
+      expect(await service.getDerivedDataSizeBytes(), isNull);
+    });
+
+    test('returns null when du output is unparseable', () async {
+      final exec = FakeCommandExec(
+        (command, args) => FakeCommandExec.ok('not-a-number\tpath\n'),
+      );
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) {
+        expect(await service.getDerivedDataSizeBytes(), isNull);
+        return;
+      }
+
+      expect(await service.getDerivedDataSizeBytes(), isNull);
+    });
+  });
+
+  group('XcodeCacheService.clearDerivedData', () {
+    test('runs rm then mkdir and reports freed size', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == 'du') {
+          return FakeCommandExec.ok('2048\t/Users/dev/Library/Developer/Xcode/DerivedData\n');
+        }
+        if (command == 'rm') return FakeCommandExec.ok();
+        if (command == 'mkdir') return FakeCommandExec.ok();
+        return null;
+      });
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) {
+        final result = await service.clearDerivedData();
+        expect(result.success, isFalse);
+        expect(result.message, contains('macOS'));
+        return;
+      }
+
+      final result = await service.clearDerivedData();
+      expect(result.success, isTrue);
+      expect(result.freedBytes, 2048 * 1024);
+      expect(result.message, contains((2048 * 1024).formatBytes));
+
+      final commands = exec.calls.map((c) => c.command).toList();
+      expect(commands, containsAllInOrder(['du', 'rm', 'mkdir']));
+      final rmCall = exec.calls.firstWhere((c) => c.command == 'rm');
+      expect(rmCall.arguments, [
+        '-rf',
+        '/Users/dev/Library/Developer/Xcode/DerivedData',
+      ]);
+      final mkdirCall = exec.calls.firstWhere((c) => c.command == 'mkdir');
+      expect(mkdirCall.arguments, [
+        '-p',
+        '/Users/dev/Library/Developer/Xcode/DerivedData',
+      ]);
+    });
+
+    test('reports already empty when size is zero', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == 'du') {
+          return FakeCommandExec.ok('0\t/Users/dev/Library/Developer/Xcode/DerivedData\n');
+        }
+        if (command == 'rm' || command == 'mkdir') return FakeCommandExec.ok();
+        return null;
+      });
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) return;
+
+      final result = await service.clearDerivedData();
+      expect(result.success, isTrue);
+      expect(result.message, contains('already empty'));
+      expect(result.freedBytes, 0);
+    });
+
+    test('fails when rm fails', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == 'du') {
+          return FakeCommandExec.ok('100\tpath\n');
+        }
+        if (command == 'rm') {
+          return FakeCommandExec.fail('Permission denied');
+        }
+        return null;
+      });
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) return;
+
+      final result = await service.clearDerivedData();
+      expect(result.success, isFalse);
+      expect(result.message, contains('Permission denied'));
+      expect(exec.calls.any((c) => c.command == 'mkdir'), isFalse);
+    });
+
+    test('fails when mkdir fails after rm', () async {
+      final exec = FakeCommandExec((command, args) {
+        if (command == 'du') return FakeCommandExec.ok('50\tpath\n');
+        if (command == 'rm') return FakeCommandExec.ok();
+        if (command == 'mkdir') return FakeCommandExec.fail('disk full');
+        return null;
+      });
+      final service = XcodeCacheService(exec, homeDirectory: '/Users/dev');
+
+      if (!Platform.isMacOS) return;
+
+      final result = await service.clearDerivedData();
+      expect(result.success, isFalse);
+      expect(result.message, contains('could not be recreated'));
+      expect(result.message, contains('disk full'));
+    });
+  });
+}

--- a/test/utils/int_extension_test.dart
+++ b/test/utils/int_extension_test.dart
@@ -1,0 +1,24 @@
+import 'package:simutil/utils/int_extension.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IntExtension.formatBytes', () {
+    test('formats zero and sub-kilobyte values as bytes', () {
+      expect(0.formatBytes, '0B');
+      expect(512.formatBytes, '512B');
+    });
+
+    test('formats KB / MB / GB scales', () {
+      expect(1024.formatBytes, '1.0K');
+      expect((10 * 1024).formatBytes, '10K');
+      expect((1024 * 1024).formatBytes, '1.0M');
+      // 3.9G ≈ 3.9 * 1024^3
+      final almostFourG = (3.9 * 1024 * 1024 * 1024).round();
+      expect(almostFourG.formatBytes, '3.9G');
+    });
+
+    test('clamps negative to zero', () {
+      expect((-1).formatBytes, '0B');
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds **Xcode Tools** to the TUI (macOS only):

- Press **`x`** to open the **Xcode Tools** menu.
- **Clear Derived Data** measures size of `~/Library/Developer/Xcode/DerivedData`, asks for confirmation (**Enter** / **Esc**), then deletes the folder and recreates it empty.
- Shell work runs through `XcodeCacheService` + `CommandExec` (size via `du -sk`, clear via `rm` + `mkdir`).
- Reusable `ConfirmDialog`, human-readable sizes via `IntExtension.formatBytes`, unit tests for service + formatter.
- Docs: README feature bullet, CHANGELOG for **0.8.0**.
- UI polish: success dialog uses themed panel (background fix); success/error dialogs no longer force a wide fixed width.

## Type of Change

- [x] 🔥 New feature (non-breaking change which adds functionality)
- [x] ✨ Enhancement (non-breaking change which improves existing functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
- [x] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 📦 Build configuration change
- [x] ✅ Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Xcode Tools, accessible with `x`, to preview and clear Xcode Derived Data after confirmation.
  * Added keyboard-friendly confirmation dialogs with Enter/Escape controls.
  * Added human-readable storage size formatting for cleanup results.

* **Bug Fixes**
  * Improved dialog sizing and corrected background colors for certain dialogs.

* **Documentation**
  * Updated the README and changelog with Xcode Tools details.

* **Release**
  * Updated the application version to 0.8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->