### PR TITLE
release: 0.8.1 — fix Derived Data home resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-07-21
+
+### Fixed
+
+- Stop resolving Xcode Derived Data under `/` when `$HOME` is missing; require an explicit home directory and fail clearly instead.
+
 ## [0.8.0] - 2026-07-21
 
 ### Added
@@ -14,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add confirmation dialog.
 - Add Xcode Tools (`x`) with Clear Derived Data — measure size, confirm, then wipe `~/Library/Developer/Xcode/DerivedData` (macOS only).
 
-## Fixed
+### Fixed
 
 - Fix background color of some dialogs.
 

--- a/lib/services/xcode_cache_service.dart
+++ b/lib/services/xcode_cache_service.dart
@@ -27,14 +27,16 @@ class XcodeCacheService {
   final CommandExec _exec;
   final String? _homeDirectory;
 
-  /// Absolute path to Derived Data for [home] (or `$HOME` / user home).
+  /// Absolute path to Derived Data for [home].
   static String derivedDataPathFor(String home) =>
       '$home/Library/Developer/Xcode/DerivedData';
 
   /// Default Derived Data path under the current user home.
-  String get derivedDataPath {
-    final home =
-        _homeDirectory ?? Platform.environment['HOME'] ?? Platform.pathSeparator;
+  ///
+  /// Returns `null` when neither [homeDirectory] nor `$HOME` is available.
+  String? get derivedDataPath {
+    final home = _homeDirectory ?? Platform.environment['HOME'];
+    if (home == null || home.isEmpty) return null;
     return derivedDataPathFor(home);
   }
 
@@ -42,6 +44,7 @@ class XcodeCacheService {
   Future<int?> getDerivedDataSizeBytes() async {
     if (!Platform.isMacOS) return null;
     final path = derivedDataPath;
+    if (path == null) return null;
     try {
       final result = await _exec.run('du', arguments: ['-sk', path]);
       if (!result.success) return null;
@@ -68,6 +71,14 @@ class XcodeCacheService {
     }
 
     final path = derivedDataPath;
+    if (path == null) {
+      return const XcodeCacheClearResult(
+        success: false,
+        message:
+            'Home directory is unavailable (set HOME or pass homeDirectory)',
+      );
+    }
+
     final sizeBefore = await getDerivedDataSizeBytes();
 
     try {

--- a/lib/simutil_app.dart
+++ b/lib/simutil_app.dart
@@ -451,6 +451,17 @@ class _SimutilAppState extends State<SimutilApp> {
   Future<void> _clearDerivedData() async {
     final service = _di.xcodeCacheService;
     final path = service.derivedDataPath;
+    if (path == null) {
+      if (!mounted) return;
+      await showErrorDialog(
+        context,
+        title: 'Clear Failed',
+        message:
+            'Home directory is unavailable (set HOME or pass homeDirectory)',
+      );
+      setState(() => _statusMessage = 'Failed to clear Derived Data');
+      return;
+    }
 
     setState(() => _statusMessage = 'Measuring Derived Data…');
     final sizeBytes = await service.getDerivedDataSizeBytes();

--- a/lib/utils/version.dart
+++ b/lib/utils/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.8.0';
+const packageVersion = '0.8.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simutil
 description: TUI application for launching Android Simulators / iOS Simulators and more ...
-version: 0.8.0
+version: 0.8.1
 repository: https://github.com/dungngminh/simutil
 
 environment:

--- a/test/services/xcode_cache_service_test.dart
+++ b/test/services/xcode_cache_service_test.dart
@@ -16,6 +16,46 @@ void main() {
     });
   });
 
+  group('XcodeCacheService.derivedDataPath', () {
+    test('uses injected homeDirectory', () {
+      final service = XcodeCacheService(
+        FakeCommandExec((command, args) => null),
+        homeDirectory: '/Users/dev',
+      );
+      expect(
+        service.derivedDataPath,
+        '/Users/dev/Library/Developer/Xcode/DerivedData',
+      );
+    });
+
+    test('returns null when home is empty', () {
+      final service = XcodeCacheService(
+        FakeCommandExec((command, args) => null),
+        homeDirectory: '',
+      );
+      expect(service.derivedDataPath, isNull);
+    });
+  });
+
+  group('XcodeCacheService.clearDerivedData home resolution', () {
+    test('fails when home is unavailable', () async {
+      final exec = FakeCommandExec((command, args) => null);
+      final service = XcodeCacheService(exec, homeDirectory: '');
+
+      if (!Platform.isMacOS) {
+        final result = await service.clearDerivedData();
+        expect(result.success, isFalse);
+        expect(result.message, contains('macOS'));
+        return;
+      }
+
+      final result = await service.clearDerivedData();
+      expect(result.success, isFalse);
+      expect(result.message, contains('Home directory is unavailable'));
+      expect(exec.calls, isEmpty);
+    });
+  });
+
   group('XcodeCacheService.getDerivedDataSizeBytes', () {
     test('parses du -sk output to bytes', () async {
       final exec = FakeCommandExec((command, args) {


### PR DESCRIPTION
## Description

Patch release **0.8.1**.

When clearing Xcode Derived Data, `derivedDataPath` previously fell back to `Platform.pathSeparator` if both the injected home and `$HOME` were missing. That could resolve to a root-relative path (`/Library/Developer/Xcode/DerivedData`) instead of under the user home.

This change:
- Makes `derivedDataPath` nullable and returns `null` when home is unavailable
- Surfaces an explicit failure from `clearDerivedData` and the TUI clear flow
- Keeps `derivedDataPathFor(home)` unchanged for valid homes
- Bumps package version to `0.8.1` and records the fix in `CHANGELOG.md`

## Type of Change

- [ ] 🔥 New feature (non-breaking change which adds functionality)
- [ ] ✨ Enhancement (non-breaking change which improves existing functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [x] 🗑️ Chore
- [ ] 📦 Build configuration change
- [x] ✅ Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Derived Data operations from using an invalid path when the home directory is unavailable.
  * Added clear error messaging when the home directory cannot be resolved.
  * The app now stops safely before attempting cleanup and displays the failure status.

* **Release**
  * Updated the version to 0.8.1.
  * Added changelog entries documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->